### PR TITLE
The support for CSD varies across the Window managers

### DIFF
--- a/widget/gtk/nsWindow.h
+++ b/widget/gtk/nsWindow.h
@@ -588,6 +588,17 @@ private:
     RefPtr<mozilla::widget::IMContextWrapper> mIMContext;
 
     mozilla::UniquePtr<mozilla::CurrentX11TimeGetter> mCurrentTimeGetter;
+    typedef enum { CSD_SUPPORT_FULL,    // CSD including shadows
+                   CSD_SUPPORT_FLAT,    // CSD without shadows
+                   CSD_SUPPORT_NONE,    // WM does not support CSD at all
+                   CSD_SUPPORT_UNKNOWN
+    } CSDSupportLevel;
+    /**
+     * Get the support of Client Side Decoration by checking
+     * the XDG_CURRENT_DESKTOP environment variable.
+     */
+    CSDSupportLevel GetCSDSupportLevel();
+    CSDSupportLevel mCSDSupportLevel;
 };
 
 #endif /* __nsWindow_h__ */


### PR DESCRIPTION
This patch introduces three level of support of CSD:
Full - WM which are able to render shadows as part of CSD (Gnome, XFCE,Cinnamon)
Flat - WM which don't support shadows but allows CSD (like KDE, LXDE, openbox)
None - WM which has no support for CSD or CSD does not make a sense (i3 and other)